### PR TITLE
Add support for GitLab, Gitee, and SourceForge

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -140,6 +140,7 @@ function replaceIcon(itemRow, provider) {
   if (!iconName) return;
 
   const newSVG = document.createElement('img');
+  newSVG.setAttribute('data-material-icons-extension', 'icon');
   newSVG.src = chrome.runtime.getURL(`${iconName}.svg`);
 
   provider.replaceIcon(svgEl, newSVG);

--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,10 @@ function replaceIcon(itemRow, provider) {
   const isLightTheme = provider.getIsLightTheme();
 
   // Get file/folder name.
-  const fileName = itemRow.querySelector(provider.selectors.filename)?.innerText.trim();
+  const fileName = itemRow
+    .querySelector(provider.selectors.filename)
+    ?.innerText.split('/')[0] // get first part of path for a proper icon lookup
+    .trim();
   if (!fileName) return; // fileName couldn't be found or we don't have a match for it.
 
   // Get file extension.
@@ -121,7 +124,6 @@ function replaceIcon(itemRow, provider) {
   }
 
   // Get folder icon from active icon pack.
-
   if (iconMap.options.activeIconPack) {
     iconName = lookForIconPackMatch(lowerFileName) ?? iconName;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -140,7 +140,6 @@ function replaceIcon(itemRow, provider) {
   if (!iconName) return;
 
   const newSVG = document.createElement('img');
-  newSVG.classList.add('material-icons-extension');
   newSVG.src = chrome.runtime.getURL(`${iconName}.svg`);
 
   provider.replaceIcon(svgEl, newSVG);

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,15 @@ const getGitProvider = () => {
     case /dev\.azure\.com/.test(href):
       return providerConfig.azure;
 
+    case /gitlab\.com/.test(href):
+      return providerConfig.gitlab;
+
+    case /gitee\.com/.test(href):
+      return providerConfig.gitee;
+
+    case /sourceforge\.net/.test(href):
+      return providerConfig.sourceforge;
+
     default:
       return null;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -102,7 +102,7 @@ function replaceIcon(itemRow, provider) {
   // Get file/folder name.
   const fileName = itemRow
     .querySelector(provider.selectors.filename)
-    ?.innerText.split('/')[0] // get first part of path for a proper icon lookup
+    ?.innerText?.split('/')[0] // get first part of path for a proper icon lookup
     .trim();
   if (!fileName) return; // fileName couldn't be found or we don't have a match for it.
 

--- a/src/main.js
+++ b/src/main.js
@@ -105,9 +105,9 @@ function replaceIcon(itemRow, provider) {
   if (!svgEl) return; // couldn't find svg element.
 
   // Get Directory or Submodule type.
-  const isDir = provider.getIsDirectory(svgEl);
-  const isSubmodule = provider.getIsSubmodule(svgEl);
-  const isSymlink = provider.getIsSymlink(svgEl);
+  const isDir = provider.getIsDirectory({ row: itemRow, icon: svgEl });
+  const isSubmodule = provider.getIsSubmodule({ row: itemRow, icon: svgEl });
+  const isSymlink = provider.getIsSymlink({ row: itemRow, icon: svgEl });
   const lowerFileName = fileName.toLowerCase();
 
   // Get icon name.

--- a/src/main.js
+++ b/src/main.js
@@ -140,6 +140,7 @@ function replaceIcon(itemRow, provider) {
   if (!iconName) return;
 
   const newSVG = document.createElement('img');
+  newSVG.classList.add('material-icons-extension');
   newSVG.src = chrome.runtime.getURL(`${iconName}.svg`);
 
   provider.replaceIcon(svgEl, newSVG);

--- a/src/manifests/base.json
+++ b/src/manifests/base.json
@@ -15,7 +15,10 @@
         "*://*.github.com/*",
         "*://*.bitbucket.org/*",
         "*://dev.azure.com/*",
-        "*://*.gitea.com/*"
+        "*://*.gitea.com/*",
+        "*://gitlab.com/*",
+        "*://gitee.com/*",
+        "*://sourceforge.net/*"
       ],
       "js": ["./main.js"],
       "run_at": "document_start"

--- a/src/manifests/chrome-edge.json
+++ b/src/manifests/chrome-edge.json
@@ -7,7 +7,10 @@
         "*://*.github.com/*",
         "*://*.bitbucket.org/*",
         "*://dev.azure.com/*",
-        "*://*.gitea.com/*"
+        "*://*.gitea.com/*",
+        "*://gitlab.com/*",
+        "*://gitee.com/*",
+        "*://sourceforge.net/*"
       ]
     }
   ]

--- a/src/providers/azure.js
+++ b/src/providers/azure.js
@@ -12,9 +12,9 @@ const azureConfig = {
   getIsLightTheme: () =>
     document.defaultView.getComputedStyle(document.body).getPropertyValue('color') ===
     'rgba(0, 0, 0, 0.9)', // TODO: There is probably a better way to determine whether Azure is in light mode
-  getIsDirectory: (svgEl) => svgEl.classList.contains('repos-folder-icon'),
+  getIsDirectory: ({ icon }) => icon.classList.contains('repos-folder-icon'),
   getIsSubmodule: () => false, // There appears to be no way to tell if a folder is a submodule
-  getIsSymlink: (svgEl) => svgEl.classList.contains('ms-Icon--PageArrowRight'),
+  getIsSymlink: ({ icon }) => icon.classList.contains('ms-Icon--PageArrowRight'),
   replaceIcon: (svgEl, newSVG) => {
     newSVG.style.display = 'inline-flex';
     newSVG.style.height = '1rem';

--- a/src/providers/bitbucket.js
+++ b/src/providers/bitbucket.js
@@ -7,8 +7,8 @@ const bitbucketConfig = {
     icon: 'svg',
   },
   getIsLightTheme: () => true, // No dark mode available for bitbucket currently
-  getIsDirectory: (svgEl) => svgEl.parentNode?.getAttribute('aria-label') === 'Directory,',
-  getIsSubmodule: (svgEl) => svgEl.parentNode?.getAttribute('aria-label') === 'Submodule,',
+  getIsDirectory: ({ icon }) => icon.parentNode?.getAttribute('aria-label') === 'Directory,',
+  getIsSubmodule: ({ icon }) => icon.parentNode?.getAttribute('aria-label') === 'Submodule,',
   getIsSymlink: () => false, // There appears to be no way to determine this for bitbucket
   replaceIcon: (svgEl, newSVG) => {
     newSVG.style.overflow = 'hidden';

--- a/src/providers/gitea.js
+++ b/src/providers/gitea.js
@@ -6,9 +6,9 @@ const giteaConfig = {
     icon: 'td.name.four.wide > span.truncate > svg',
   },
   getIsLightTheme: () => false,
-  getIsDirectory: (svgEl) => svgEl.classList.contains('octicon-file-directory-fill'),
-  getIsSubmodule: (svgEl) => svgEl.classList.contains('octicon-file-submodule'),
-  getIsSymlink: (svgEl) => svgEl.classList.contains('octicon-file-symlink-file'),
+  getIsDirectory: ({ icon }) => icon.classList.contains('octicon-file-directory-fill'),
+  getIsSubmodule: ({ icon }) => icon.classList.contains('octicon-file-submodule'),
+  getIsSymlink: ({ icon }) => icon.classList.contains('octicon-file-symlink-file'),
   replaceIcon: (svgEl, newSVG) => {
     svgEl
       .getAttributeNames()

--- a/src/providers/gitee.js
+++ b/src/providers/gitee.js
@@ -3,8 +3,8 @@ const giteeConfig = {
   selectors: {
     // File list row, README header, file view header
     row: '#git-project-content .tree-content .row.tree-item, .file_title, .blob-description',
-    // File name table cell, file view header
-    filename: '[class*="tree-item-"], span.file_name',
+    // File name table cell, Submodule name table cell, file view header
+    filename: '.tree-list-item > a, .tree-item-submodule-name a, span.file_name',
     // The iconfont icon not including the delete button icon in the file view header
     icon: 'i.iconfont:not(.icon-delete)',
   },

--- a/src/providers/gitee.js
+++ b/src/providers/gitee.js
@@ -1,0 +1,28 @@
+const giteeConfig = {
+  name: 'gitee',
+  selectors: {
+    // File list row, README header, file view header
+    row: '#git-project-content .tree-content .row.tree-item, .file_title, .blob-description',
+    // File name table cell, file view header
+    filename: '[class*="tree-item-"], span.file_name',
+    // The iconfont icon not including the delete button icon in the file view header
+    icon: 'i.iconfont:not(.icon-delete)',
+  },
+  getIsLightTheme: () => true, // There appears to be no dark theme available for gitee.
+  getIsDirectory: ({ icon }) => icon.classList.contains('icon-folders'),
+  getIsSubmodule: ({ icon }) => icon.classList.contains('icon-submodule'),
+  getIsSymlink: ({ icon }) => icon.classList.contains('icon-file-shortcut'),
+  replaceIcon: (svgEl, newSVG) => {
+    svgEl
+      .getAttributeNames()
+      .forEach((attr) => newSVG.setAttribute(attr, svgEl.getAttribute(attr)));
+
+    newSVG.style.height = '28px';
+    newSVG.style.width = '18px';
+
+    svgEl.parentNode.replaceChild(newSVG, svgEl);
+  },
+  onAdd: () => {},
+};
+
+export default giteeConfig;

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -4,7 +4,7 @@ const githubConfig = {
     row: '.js-navigation-container[role=grid] > .js-navigation-item, file-tree .ActionList-content, a.tree-browser-result',
     filename:
       'div[role="rowheader"] > span, .ActionList-item-label, a.tree-browser-result > marked-text',
-    icon: '.octicon-file, .octicon-file-directory-fill, a.tree-browser-result > svg.octicon.octicon-file',
+    icon: '.octicon-file, .octicon-file-directory-fill, .octicon-file-submodule, a.tree-browser-result > svg.octicon.octicon-file',
   },
   getIsLightTheme: () => document.querySelector('html').getAttribute('data-color-mode') === 'light',
   getIsDirectory: ({ icon }) => icon.getAttribute('aria-label') === 'Directory',

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -7,9 +7,9 @@ const githubConfig = {
     icon: '.octicon-file, .octicon-file-directory-fill, a.tree-browser-result > svg.octicon.octicon-file',
   },
   getIsLightTheme: () => document.querySelector('html').getAttribute('data-color-mode') === 'light',
-  getIsDirectory: (svgEl) => svgEl.getAttribute('aria-label') === 'Directory',
-  getIsSubmodule: (svgEl) => svgEl.getAttribute('aria-label') === 'Submodule',
-  getIsSymlink: (svgEl) => svgEl.getAttribute('aria-label') === 'Symlink Directory',
+  getIsDirectory: ({ icon }) => icon.getAttribute('aria-label') === 'Directory',
+  getIsSubmodule: ({ icon }) => icon.getAttribute('aria-label') === 'Submodule',
+  getIsSymlink: ({ icon }) => icon.getAttribute('aria-label') === 'Symlink Directory',
   replaceIcon: (svgEl, newSVG) => {
     svgEl
       .getAttributeNames()

--- a/src/providers/gitlab.js
+++ b/src/providers/gitlab.js
@@ -1,0 +1,28 @@
+const gitlabConfig = {
+  name: 'gitlab',
+  selectors: {
+    // Row in file list, file view header
+    row: 'table[data-qa-selector="file_tree_table"] tr, .file-header-content',
+    // Cell in file list, file view header, readme header
+    filename: 'td.tree-item-file-name, .file-title-name, .gl-link',
+    // Any icon not contained in a button
+    icon: 'svg:not(.gl-button-icon)',
+  },
+  getIsLightTheme: () => !document.querySelector('body').classList.contains('gl-dark'),
+  getIsDirectory: ({ icon }) => icon.getAttribute('data-testid') === 'folder-icon',
+  getIsSubmodule: ({ row }) => row.querySelector('a')?.classList.contains('is-submodule') || false,
+  getIsSymlink: ({ icon }) => icon.getAttribute('data-testid') === 'symlink-icon',
+  replaceIcon: (svgEl, newSVG) => {
+    svgEl
+      .getAttributeNames()
+      .forEach((attr) => newSVG.setAttribute(attr, svgEl.getAttribute(attr)));
+
+    newSVG.style.height = '16px';
+    newSVG.style.width = '16px';
+
+    svgEl.parentNode.replaceChild(newSVG, svgEl);
+  },
+  onAdd: () => {},
+};
+
+export default gitlabConfig;

--- a/src/providers/gitlab.js
+++ b/src/providers/gitlab.js
@@ -4,9 +4,10 @@ const gitlabConfig = {
     // Row in file list, file view header
     row: 'table[data-qa-selector="file_tree_table"] tr, .file-header-content',
     // Cell in file list, file view header, readme header
-    filename: 'td.tree-item-file-name, .file-title-name, .gl-link',
+    filename:
+      'td.tree-item-file-name, .file-header-content .file-title-name, .file-header-content .gl-link',
     // Any icon not contained in a button
-    icon: 'svg:not(.gl-button-icon)',
+    icon: '.tree-item svg, .file-header-content svg:not(.gl-button-icon)',
   },
   getIsLightTheme: () => !document.querySelector('body').classList.contains('gl-dark'),
   getIsDirectory: ({ icon }) => icon.getAttribute('data-testid') === 'folder-icon',

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -2,12 +2,18 @@ import githubConfig from './github';
 import bitbucketConfig from './bitbucket';
 import azureConfig from './azure';
 import giteaConfig from './gitea';
+import gitlabConfig from './gitlab';
+import giteeConfig from './gitee';
+import sourceforgeConfig from './sourceforge';
 
 const providerConfig = {
   github: githubConfig,
   bitbucket: bitbucketConfig,
   azure: azureConfig,
   gitea: giteaConfig,
+  gitlab: gitlabConfig,
+  gitee: giteeConfig,
+  sourceforge: sourceforgeConfig,
 };
 
 export default providerConfig;

--- a/src/providers/sourceforge.js
+++ b/src/providers/sourceforge.js
@@ -4,9 +4,9 @@ const sourceforgeConfig = {
     // File list row, README header, file view header
     row: 'table#files_list tr, #content_base tr td:first-child',
     // File name table cell, file view header
-    filename: 'th, a.icon',
+    filename: 'th[headers="files_name_h"], td:first-child > a.icon',
     // The iconfont icon not including the delete button icon in the file view header
-    icon: 'a:not(.icon), i.fa',
+    icon: 'th[headers="files_name_h"] > a, a.icon > i.fa',
   },
   getIsLightTheme: () => true, // There appears to be no dark theme available for sourceforge.
   getIsDirectory: ({ row, icon }) => {

--- a/src/providers/sourceforge.js
+++ b/src/providers/sourceforge.js
@@ -8,7 +8,7 @@ const sourceforgeConfig = {
     // The iconfont icon not including the delete button icon in the file view header
     icon: 'a:not(.icon), i.fa',
   },
-  getIsLightTheme: () => true, // There appears to be no dark theme available for gitee.
+  getIsLightTheme: () => true, // There appears to be no dark theme available for sourceforge.
   getIsDirectory: ({ row, icon }) => {
     if (icon.nodeName === 'I') {
       return icon.classList.contains('fa-folder');

--- a/src/providers/sourceforge.js
+++ b/src/providers/sourceforge.js
@@ -1,0 +1,58 @@
+const sourceforgeConfig = {
+  name: 'sourceforge',
+  selectors: {
+    // File list row, README header, file view header
+    row: 'table#files_list tr, #content_base tr td:first-child',
+    // File name table cell, file view header
+    filename: 'th, a.icon',
+    // The iconfont icon not including the delete button icon in the file view header
+    icon: 'a:not(.icon), i.fa',
+  },
+  getIsLightTheme: () => true, // There appears to be no dark theme available for gitee.
+  getIsDirectory: ({ row, icon }) => {
+    if (icon.nodeName === 'I') {
+      return icon.classList.contains('fa-folder');
+    }
+
+    return row.classList.contains('folder');
+  },
+  getIsSubmodule: () => false,
+  getIsSymlink: ({ icon }) => {
+    if (icon.nodeName === 'I') {
+      return icon.classList.contains('fa-star');
+    }
+
+    return false;
+  },
+  replaceIcon: (iconOrAnchor, newSVG) => {
+    newSVG.style.verticalAlign = 'text-bottom';
+
+    if (iconOrAnchor.nodeName === 'I') {
+      newSVG.style.height = '14px';
+      newSVG.style.width = '14px';
+
+      iconOrAnchor.parentNode.replaceChild(newSVG, iconOrAnchor);
+    }
+    // For the files list, use the anchor element instead of the icon because in some cases there is no icon
+    else {
+      if (iconOrAnchor.querySelector('img')) {
+        // only replace/prepend the icon once
+        return;
+      }
+
+      newSVG.style.height = '20px';
+      newSVG.style.width = '20px';
+
+      const svgEl = iconOrAnchor.querySelector('svg');
+
+      if (svgEl) {
+        svgEl.parentNode.replaceChild(newSVG, svgEl);
+      } else {
+        iconOrAnchor.prepend(newSVG);
+      }
+    }
+  },
+  onAdd: () => {},
+};
+
+export default sourceforgeConfig;

--- a/src/providers/sourceforge.js
+++ b/src/providers/sourceforge.js
@@ -26,6 +26,7 @@ const sourceforgeConfig = {
   },
   replaceIcon: (iconOrAnchor, newSVG) => {
     newSVG.style.verticalAlign = 'text-bottom';
+    newSVG.classList.add('material-icons-extension');
 
     if (iconOrAnchor.nodeName === 'I') {
       newSVG.style.height = '14px';

--- a/src/providers/sourceforge.js
+++ b/src/providers/sourceforge.js
@@ -26,7 +26,6 @@ const sourceforgeConfig = {
   },
   replaceIcon: (iconOrAnchor, newSVG) => {
     newSVG.style.verticalAlign = 'text-bottom';
-    newSVG.classList.add('material-icons-extension');
 
     if (iconOrAnchor.nodeName === 'I') {
       newSVG.style.height = '14px';
@@ -36,7 +35,7 @@ const sourceforgeConfig = {
     }
     // For the files list, use the anchor element instead of the icon because in some cases there is no icon
     else {
-      if (iconOrAnchor.querySelector('.material-icons-extension')) {
+      if (iconOrAnchor.querySelector('img[data-material-icons-extension="icon"]')) {
         // only replace/prepend the icon once
         return;
       }

--- a/src/providers/sourceforge.js
+++ b/src/providers/sourceforge.js
@@ -35,7 +35,7 @@ const sourceforgeConfig = {
     }
     // For the files list, use the anchor element instead of the icon because in some cases there is no icon
     else {
-      if (iconOrAnchor.querySelector('img')) {
+      if (iconOrAnchor.querySelector('.material-icons-extension')) {
         // only replace/prepend the icon once
         return;
       }


### PR DESCRIPTION
As the title says, this PR adds support for GitLab, Gitee, and SourceForge, and would close #2.  GitLab was originally requested in that issue, but the other two were not. Like I had mentioned in a comment, I've looked through a bunch of these extensions, and some of them have support for Gitee and some have support for SourceForge, so I decided to try adding both of them.  The results look pretty good IMO.

Before I talk about those, I made two other small general tweaks that I'd like to point out.

1. I switched the filename getter to take the first part of a path (split on `/`) if the name is representative of a path.  For example, when there's only one folder inside another folder, GitHub concatenated the names and clicking sends you straight through to the second folder.  In general, I've found that the top level folder in these situations is more likely to have a custom icon, so I used the first part of the path.  However, it could technically make more sense to use the end part of the path, as that's where the link goes.  Either way, up to you whether you want to keep this change.

<img width="919" alt="image" src="https://user-images.githubusercontent.com/9214195/176955549-cbcbdc0a-b8c0-481d-9c33-241388f58388.png">

2. In order to get these new providers working, I changed the structure of the `getIsDirectory`, `getIsSubmodule`, and `getIsSymlink` functions to accept an object with the shape `{ row, icon }`.  In some cases, you can not determine these features from the icon itself, and having access to the `row` element gives a lot more freedom for figuring that out. It was possible to get the same features from the row by chaining `.parentNode` but I've never felt super comfortable with traversing up a DOM tree.  Plus, it's still about as simple to implement these functions as you can just destructure the part you need:

```js
getIsDirectory: ({ icon }) => icon.getAttribute('data-testid') === 'folder-icon',
getIsSubmodule: ({ row }) => row.querySelector('a')?.classList.contains('is-submodule') || false,
```

So here's some info on the new providers:

## GitLab

Like I mentioned, the main purpose of adding GitLab support is so that the folders get icons.  Besides that it is mostly similar.

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/9214195/176956332-9a8e525a-c906-4c5b-a912-9f997bcd5d0d.png">

One extra feature I added however, was replacing the icon for the Readme shown below the list of files:

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/9214195/176956416-ecce48c6-08a7-4897-b9c4-e4b2f2c25cbd.png">

As well as the icon you see when viewing a specific file:

<img width="1447" alt="image" src="https://user-images.githubusercontent.com/9214195/176956520-ce4be3db-078f-4578-b7a9-8dff35d60870.png">

I'm sure you have plenty of repos you can test this with as you mentioned you're now using GitLab for work, but here's an instance of that test repo I shared with you that I pushed to GitLab: https://gitlab.com/csandman/test

## Gitee

I'm not gonna lie, I had never heard of Gitee until I saw another extension supporting it, but it has a very similar layout to GitLab.  I did the same replacements as I did on GitLab, the file table, readme title, and individual file titles:

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/9214195/176956850-db939f8a-8392-4d9c-8d8d-fb8eaed0b040.png">

<img width="1330" alt="image" src="https://user-images.githubusercontent.com/9214195/176956922-156d6567-94a8-4a0b-8371-6a870a89cc59.png">

I tested the symlink/submodule getters using that same repo but I don't feel like making it public because they have an approval process for that and I don't want to deal with it.  You can test it with any of the repos on their explore page: https://gitee.com/explore

## SourceForge

For SourceForge, I had to handle things a little differently than the rest.  Each project has both a code page as well as a files page with a list of downloadable output files.  I decided both would benefit from this replacement.  However, on the Files page, only the folders have an icon by default, so I targeted the element wrapping the icon, replaced the child icon if it does exist, and prepended the new icon if it does not.

Here's the Files page:

<img width="1421" alt="image" src="https://user-images.githubusercontent.com/9214195/176957337-1cbadffb-777a-448e-b14a-8767034b0919.png">

And here's the Code page:

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/9214195/176957383-388635b3-2194-41a2-947b-fc95fc983cb8.png">

You can check out the code page for my test repo mentioned above here: https://sourceforge.net/p/csandman-test/code/ci/main/tree/

And you can check the files page for any of the public projects listed here: https://sourceforge.net/directory/

Let me know if anything needs changing!