### PR TITLE
Add support for GitHub's new code view

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -4,7 +4,7 @@ const githubConfig = {
     row: '.js-navigation-container[role=grid] > .js-navigation-item, file-tree .ActionList-content, a.tree-browser-result, tr.react-directory-row, div.PRIVATE_TreeView-item-content',
     filename:
       'div[role="rowheader"] > span, .ActionList-item-label, a.tree-browser-result > marked-text, .react-directory-truncate, .PRIVATE_TreeView-item-content-text',
-    icon: '.octicon-file, .octicon-file-directory-fill, .octicon-file-submodule, a.tree-browser-result > svg.octicon.octicon-file, .react-directory-filename-column svg, .PRIVATE_TreeView-item-visual svg.octicon',
+    icon: '.octicon-file, .octicon-file-directory-fill, .octicon-file-submodule, a.tree-browser-result > svg.octicon.octicon-file, .react-directory-filename-column svg, .PRIVATE_TreeView-directory-icon > svg.octicon, .PRIVATE_TreeView-item-visual > svg.octicon',
   },
   getIsLightTheme: () => document.querySelector('html').getAttribute('data-color-mode') === 'light',
   getIsDirectory: ({ icon }) => icon.getAttribute('aria-label') === 'Directory' || icon.getAttribute('class')?.includes('directory'),

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -1,15 +1,15 @@
 const githubConfig = {
   domain: 'github.com',
   selectors: {
-    row: '.js-navigation-container[role=grid] > .js-navigation-item, file-tree .ActionList-content, a.tree-browser-result',
+    row: '.js-navigation-container[role=grid] > .js-navigation-item, file-tree .ActionList-content, a.tree-browser-result, tr.react-directory-row, div.PRIVATE_TreeView-item-content',
     filename:
-      'div[role="rowheader"] > span, .ActionList-item-label, a.tree-browser-result > marked-text',
-    icon: '.octicon-file, .octicon-file-directory-fill, .octicon-file-submodule, a.tree-browser-result > svg.octicon.octicon-file',
+      'div[role="rowheader"] > span, .ActionList-item-label, a.tree-browser-result > marked-text, .react-directory-truncate, .PRIVATE_TreeView-item-content-text',
+    icon: '.octicon-file, .octicon-file-directory-fill, .octicon-file-submodule, a.tree-browser-result > svg.octicon.octicon-file, .react-directory-filename-column svg, .PRIVATE_TreeView-item-visual svg.octicon',
   },
   getIsLightTheme: () => document.querySelector('html').getAttribute('data-color-mode') === 'light',
-  getIsDirectory: ({ icon }) => icon.getAttribute('aria-label') === 'Directory',
-  getIsSubmodule: ({ icon }) => icon.getAttribute('aria-label') === 'Submodule',
-  getIsSymlink: ({ icon }) => icon.getAttribute('aria-label') === 'Symlink Directory',
+  getIsDirectory: ({ icon }) => icon.getAttribute('aria-label') === 'Directory' || icon.getAttribute('class')?.includes('directory'),
+  getIsSubmodule: ({ icon, row }) => icon.getAttribute('aria-label') === 'Submodule' || row.querySelector('.react-directory-filename-column .sr-only')?.innerText === '(Submodule)',
+  getIsSymlink: ({ icon, row }) => icon.getAttribute('aria-label') === 'Symlink Directory' || row.querySelector('.react-directory-filename-column .sr-only')?.innerText === '(Symlink to file)',
   replaceIcon: (svgEl, newSVG) => {
     svgEl
       .getAttributeNames()


### PR DESCRIPTION
I added extra css selectors for the new code view (for both the main panel and the side bar), I also modified the other functions to detect directories/submodules/symlinks in the main panel (the side bar does not display them correctly atm)

![image](https://user-images.githubusercontent.com/47293197/208264411-fa7faa96-3e55-4029-b944-8d2d94955848.png)

This should resolve #47

