### PR TITLE
GitHub Code View Support

### DIFF
--- a/src/injected-styles.css
+++ b/src/injected-styles.css
@@ -10,7 +10,7 @@ body[data-material-icons-extension-size='xl'] img[data-material-icons-extension=
   transform: scale(1.25);
 }
 
-.github-material-icons-exension-hide-pseudo::before {
+.material-icons-exension-hide-pseudo::before {
   display: none !important;
 }
 

--- a/src/injected-styles.css
+++ b/src/injected-styles.css
@@ -13,3 +13,13 @@ body[data-material-icons-extension-size='xl'] img[data-material-icons-extension=
 .github-material-icons-exension-hide-pseudo::before {
   display: none !important;
 }
+
+.github-material-icons-exension-hide {
+  display: none !important;
+}
+
+/* Hide the directory icons in GitHub's new code view in case they don't get
+hidden automatically (happens when a folder is expanded or collapsed) */
+.PRIVATE_TreeView-directory-icon svg {
+  display: none !important;
+}

--- a/src/injected-styles.css
+++ b/src/injected-styles.css
@@ -9,3 +9,7 @@ body[data-material-icons-extension-size='lg'] img[data-material-icons-extension=
 body[data-material-icons-extension-size='xl'] img[data-material-icons-extension='icon'] {
   transform: scale(1.25);
 }
+
+.github-material-icons-exension-hide-pseudo::before {
+  display: none !important;
+}

--- a/src/injected-styles.css
+++ b/src/injected-styles.css
@@ -14,12 +14,7 @@ body[data-material-icons-extension-size='xl'] img[data-material-icons-extension=
   display: none !important;
 }
 
-.github-material-icons-exension-hide {
-  display: none !important;
-}
-
-/* Hide the directory icons in GitHub's new code view in case they don't get
-hidden automatically (happens when a folder is expanded or collapsed) */
-.PRIVATE_TreeView-directory-icon svg {
+/* Hide any svg following a custom icon from this extension */
+img[data-material-icons-extension='icon'] + svg {
   display: none !important;
 }

--- a/src/providers/azure.js
+++ b/src/providers/azure.js
@@ -1,5 +1,5 @@
 /** The name of the class used to hide the pseudo element `:before` on Azure */
-const HIDE_PSEUDO_CLASS = 'github-material-icons-exension-hide-pseudo';
+const HIDE_PSEUDO_CLASS = 'material-icons-exension-hide-pseudo';
 
 const azureConfig = {
   domain: 'dev.azure.com',

--- a/src/providers/azure.js
+++ b/src/providers/azure.js
@@ -1,6 +1,5 @@
 /** The name of the class used to hide the pseudo element `:before` on Azure */
-const HIDE_PSEUDO_CLASS = 'hide-pseudo';
-let hasAddedAzureStyle = false;
+const HIDE_PSEUDO_CLASS = 'github-material-icons-exension-hide-pseudo';
 
 const azureConfig = {
   domain: 'dev.azure.com',
@@ -52,16 +51,6 @@ const azureConfig = {
 
     const observer = new MutationObserver(mutationCallback);
     observer.observe(row, { attributes: true, childList: true, subtree: true });
-
-    if (!hasAddedAzureStyle) {
-      // Azure requires the icon element to be left on the page so add a style rule to hide its icon
-      document.styleSheets[0].insertRule(
-        `.${HIDE_PSEUDO_CLASS}::before { display: none !important }`,
-        0
-      );
-      // but only add the style once
-      hasAddedAzureStyle = true;
-    }
   },
 };
 

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -1,5 +1,3 @@
-const HIDE_ELEMENT_CLASS = 'github-material-icons-exension-hide';
-
 const githubConfig = {
   domain: 'github.com',
   selectors: {
@@ -32,10 +30,6 @@ const githubConfig = {
     newSVG.style.width = '1rem';
     newSVG.style.verticalAlign = 'text-bottom';
     newSVG.style.userSelect = 'none';
-
-    if (!svgEl.classList.contains(HIDE_ELEMENT_CLASS)) {
-      svgEl.classList.add(HIDE_ELEMENT_CLASS);
-    }
 
     // Instead of replacing the icon, add the new icon as a previous sibling,
     // otherwise the GitHub code view crashes when you navigate through the

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -26,10 +26,14 @@ const githubConfig = {
   getIsSubmodule: ({ icon }) => icon.getAttribute('aria-label') === 'Submodule',
   getIsSymlink: ({ icon }) => icon.getAttribute('aria-label') === 'Symlink Directory',
   replaceIcon: (svgEl, newSVG) => {
-    newSVG.style.height = '1rem';
-    newSVG.style.width = '1rem';
-    newSVG.style.verticalAlign = 'text-bottom';
-    newSVG.style.userSelect = 'none';
+    svgEl
+      .getAttributeNames()
+      .forEach(
+        (attr) =>
+          attr !== 'src' &&
+          !/^data-material-icons-extension/.test(attr) &&
+          newSVG.setAttribute(attr, svgEl.getAttribute(attr))
+      );
 
     // Instead of replacing the icon, add the new icon as a previous sibling,
     // otherwise the GitHub code view crashes when you navigate through the

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -1,26 +1,51 @@
+const HIDE_ELEMENT_CLASS = 'github-material-icons-exension-hide';
+
 const githubConfig = {
   domain: 'github.com',
   selectors: {
-    row: '.js-navigation-container[role=grid] > .js-navigation-item, file-tree .ActionList-content, a.tree-browser-result',
-    filename:
-      'div[role="rowheader"] > span, .ActionList-item-label, a.tree-browser-result > marked-text',
-    icon: '.octicon-file, .octicon-file-directory-fill, .octicon-file-submodule, a.tree-browser-result > svg.octicon.octicon-file',
+    row: `.js-navigation-container[role=grid] > .js-navigation-item,
+      file-tree .ActionList-content,
+      a.tree-browser-result,
+      .PRIVATE_TreeView-item-content,
+      .react-directory-filename-column`,
+    filename: `div[role="rowheader"] > span,
+      .ActionList-item-label,
+      a.tree-browser-result > marked-text,
+      .PRIVATE_TreeView-item-content > .PRIVATE_TreeView-item-content-text,
+      .react-directory-filename-column h3`,
+    icon: `.octicon-file,
+      .octicon-file-directory-fill,
+      .octicon-file-directory-open-fill,
+      .octicon-file-submodule,
+      .react-directory-filename-column > svg`,
   },
   getIsLightTheme: () => document.querySelector('html').getAttribute('data-color-mode') === 'light',
-  getIsDirectory: ({ icon }) => icon.getAttribute('aria-label') === 'Directory',
+  getIsDirectory: ({ icon }) =>
+    icon.getAttribute('aria-label') === 'Directory' ||
+    icon.classList.contains('octicon-file-directory-fill') ||
+    icon.classList.contains('octicon-file-directory-open-fill') ||
+    icon.classList.contains('icon-directory'),
   getIsSubmodule: ({ icon }) => icon.getAttribute('aria-label') === 'Submodule',
   getIsSymlink: ({ icon }) => icon.getAttribute('aria-label') === 'Symlink Directory',
   replaceIcon: (svgEl, newSVG) => {
-    svgEl
-      .getAttributeNames()
-      .forEach(
-        (attr) =>
-          attr !== 'src' &&
-          !/^data-material-icons-extension/.test(attr) &&
-          newSVG.setAttribute(attr, svgEl.getAttribute(attr))
-      );
+    newSVG.style.height = '1rem';
+    newSVG.style.width = '1rem';
+    newSVG.style.verticalAlign = 'text-bottom';
+    newSVG.style.userSelect = 'none';
 
-    svgEl.parentNode.replaceChild(newSVG, svgEl);
+    if (!svgEl.classList.contains(HIDE_ELEMENT_CLASS)) {
+      svgEl.classList.add(HIDE_ELEMENT_CLASS);
+    }
+
+    // Instead of replacing the icon, add the new icon as a previous sibling,
+    // otherwise the GitHub code view crashes when you navigate through the
+    // tree view
+    const prevEl = svgEl.previousElementSibling;
+    if (prevEl?.getAttribute('data-material-icons-extension') === 'icon') {
+      svgEl.parentNode.replaceChild(newSVG, prevEl);
+    } else {
+      svgEl.parentNode.insertBefore(newSVG, svgEl);
+    }
   },
   onAdd: () => {},
 };


### PR DESCRIPTION
This PR closes #55

In order to support GitHub's new code view (which is currently only in preview mode and is still potentially subject to change), there was more involved in the icon replacement than simply adding new selectors, which I already mentioned in this comment: https://github.com/Claudiohbsantos/github-material-icons-extension/issues/55#issuecomment-1447100048.

The first change I made was somewhat unrelated, but I felt it was a good choice for consistency. I moved the style injected into the stylesheet on the Azure website into the normal injected stylesheet, which is used for the icon sizing. I think this makes more sense than checking if the style has been added over and over. I did, however, also change the name of the "hide pseudo" class to be more specific to ensure this style doesn't conflict with any other git providers' built in class names.

Next, I added the new selectors required as per usual. I ended up splitting them onto multiple lines, as they were getting really long and difficult to read. This also let me realize that two of the selectors were redundant (probably my fault haha):

```css
.octicon-file, a.tree-browser-result > svg.octicon.octicon-file
```

so I removed the second of these two.

And then came some complications. Like I mention in the comment above, the nature of the tree view used by the new code view is different from the PR code view. For these, if you replace the icon with the custom icon, React (what GitHub is made with) will break every time you navigate to a new sub-folder, or expand/collapse one of the folders in the sidebar. So I used a similar approach to how I replaced the icons in Azure. Instead of straight up replacing them, I added them as a sibling to the old icon and added a class to the old icon to hide it.

This worked quite well for the most part, except for the open/closed folder icons on the sidebar. When you click on the caret to open them, the selector observer is not triggered, so the new icon never receives the class it needs to hide the old icon.

<img width="396" alt="image" src="https://user-images.githubusercontent.com/9214195/221710743-2d67b109-519d-4e9c-83b6-cc35ae904e15.png">

---

<img width="392" alt="image" src="https://user-images.githubusercontent.com/9214195/221710634-85bfb0b1-d23d-49ca-881e-7bf68a340368.png">

The way I managed to solve this was simply by adding a global style to hide that specific icon type:

```css
.PRIVATE_TreeView-directory-icon svg {
  display: none !important;
}
```

The problem with this approach is that on first load, the icons are entirely hidden, which causes a layout shift of the directory names when the icons are replaced... and while writing this, I actually realized a more consistent approach would just be to add a sibling selector from the custom icons. That way, the old icon is only hidden once it is replaced by the new one, and we don't need a custom class on the old icon in order to hide it:

```css
img[data-material-icons-extension='icon'] + svg {
  display: none !important;
}
```

I would have made the selector more specific, like `svg.octicon`, but for some reason the icons inside the main body of the code view don't have the same classes as the rest. I don't believe there are any other cases where an SVG immediately follows the custom icons in any of the other Git providers, though, so I think this should be fine.

I also tested this strategy of adding the new icon as a sibling across all the different GitHub pages where this extension functions, and it appears that it works well on all of them.

---

The one other issue I ran into is the Parent Directory icon isn't replaced in the same way as the others.

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/9214195/221715214-84c9133c-c35f-4664-a434-07a50af9bde8.png">

It does not follow the same class naming conventions that the rest of the rows in the table do, so it wasn't the simplest thing to target. I did manage to find some selectors that worked, but they feel way too general. Here is what I tried that worked:

```js
  selectors: {
    row: `.js-navigation-container[role=grid] > .js-navigation-item,
      file-tree .ActionList-content,
      a.tree-browser-result,
      .PRIVATE_TreeView-item-content,
      table[aria-labelledby="folders-and-files"] tr`, // This is the closest I could get to a specific selector
    filename: `div[role="rowheader"] > span,
      .ActionList-item-label,
      a.tree-browser-result > marked-text,
      .PRIVATE_TreeView-item-content > .PRIVATE_TreeView-item-content-text,
      tr h3`, // Very general
    icon: `.octicon-file,
      .octicon-file-directory-fill,
      .octicon-file-directory-open-fill,
      .octicon-file-submodule,
      tr svg`, // Also very general
  },
  getIsLightTheme: () => document.querySelector('html').getAttribute('data-color-mode') === 'light',
  getIsDirectory: ({ icon, row }) =>
    icon.getAttribute('aria-label') === 'Directory' ||
    icon.classList.contains('octicon-file-directory-fill') ||
    icon.classList.contains('octicon-file-directory-open-fill') ||
    icon.classList.contains('icon-directory') ||
    row.innerText.includes('directory'), // Used for the "preious directory" link in the code view
```

I can switch to this approach if you'd like, otherwise I can leave it out! Let me know if you have any thoughts on the way I implemented things as well.