### PR TITLE
Fix the extra icons added when changing icon packs

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -41,7 +41,13 @@ const githubConfig = {
     const prevEl = svgEl.previousElementSibling;
     if (prevEl?.getAttribute('data-material-icons-extension') === 'icon') {
       svgEl.parentNode.replaceChild(newSVG, prevEl);
-    } else {
+    }
+    // If the icon to replace is an icon from this extension, replace it with the new icon
+    else if (svgEl.getAttribute('data-material-icons-extension') === 'icon') {
+      svgEl.parentNode.replaceChild(newSVG, svgEl);
+    }
+    // If neither of the above, prepend the new icon in front of the original icon
+    else {
       svgEl.parentNode.insertBefore(newSVG, svgEl);
     }
   },


### PR DESCRIPTION
Closes #63 

This PR fixes the issue of the extra icons being added when the icon packs are switched. It appears the issue is being caused by the prepend behavior I used for the new icons. In the case where you attempt to replace the icon from this pack, it doesn't see a previous sibling with the icon pack, so it just prepends it.

The fix was checking to see if the `svgEl` the extension is looking at actually comes from this pack, and in the case where it does, actually do a replace instead of prepending it.