### PR TITLE
Fix conflict with Refined GitHub

### DIFF
--- a/src/injected-styles.css
+++ b/src/injected-styles.css
@@ -13,8 +13,3 @@ body[data-material-icons-extension-size='xl'] img[data-material-icons-extension=
 .material-icons-exension-hide-pseudo::before {
   display: none !important;
 }
-
-/* Hide any svg following a custom icon from this extension */
-img[data-material-icons-extension='icon'] + svg {
-  display: none !important;
-}

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -35,20 +35,21 @@ const githubConfig = {
           newSVG.setAttribute(attr, svgEl.getAttribute(attr))
       );
 
-    // Instead of replacing the icon, add the new icon as a previous sibling,
-    // otherwise the GitHub code view crashes when you navigate through the
-    // tree view
     const prevEl = svgEl.previousElementSibling;
     if (prevEl?.getAttribute('data-material-icons-extension') === 'icon') {
-      svgEl.parentNode.replaceChild(newSVG, prevEl);
+      newSVG.replaceWith(prevEl);
     }
     // If the icon to replace is an icon from this extension, replace it with the new icon
     else if (svgEl.getAttribute('data-material-icons-extension') === 'icon') {
-      svgEl.parentNode.replaceChild(newSVG, svgEl);
+      newSVG.replaceWith(svgEl);
     }
-    // If neither of the above, prepend the new icon in front of the original icon
+    // If neither of the above, prepend the new icon in front of the original icon.
+    // If we remove the icon, GitHub code view crashes when you navigate through the
+    // tree view. Instead, we just hide it via `style` attribute (not CSS class)
+    // https://github.com/Claudiohbsantos/github-material-icons-extension/pull/66
     else {
-      svgEl.parentNode.insertBefore(newSVG, svgEl);
+      svgEl.style.display = 'none';
+      svgEl.before(newSVG);
     }
   },
   onAdd: () => {},


### PR DESCRIPTION
- Closes #65 

![2](https://user-images.githubusercontent.com/1402241/236658314-ed87a25e-fb4a-4cc7-a0d1-bb5e6d90195d.gif)

Testable on: 

- https://github.com/Claudiohbsantos/github-material-icons-extension

Subfolders weren't affected:

- https://github.com/Claudiohbsantos/github-material-icons-extension/tree/master/src