### PR TITLE
fix: Replace property checking with `hasOwnProperty` wrapper

### DIFF
--- a/scripts/build-src.js
+++ b/scripts/build-src.js
@@ -58,7 +58,14 @@ function src(distPath) {
 
   const copyExtensionLogos = fs.copy(path.resolve(srcPath, 'extensionIcons'), distPath);
 
-  return Promise.all([copyExtensionLogos, copyOptions, copyPopup, copyStyles, copyIcons, bundleAll]);
+  return Promise.all([
+    copyExtensionLogos,
+    copyOptions,
+    copyPopup,
+    copyStyles,
+    copyIcons,
+    bundleAll,
+  ]);
 }
 
 function buildManifest(distPath, manifestName) {

--- a/src/lib/replace-icon.js
+++ b/src/lib/replace-icon.js
@@ -3,6 +3,18 @@ import iconMap from '../icon-map.json';
 import languageMap from '../language-map.json';
 
 /**
+ * A helper function to check if an object has a key value, without including prooerties from the prototype chain.
+ *
+ * @see https://eslint.org/docs/latest/rules/no-prototype-builtins
+ * @param {object} obj An object to check for a key.
+ * @param {string} key A string represeing a key to find in the object.
+ * @returns {boolean} Whether the object contains the key or not.
+ */
+function objectHas(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/**
  * Replace file/folder icons.
  *
  * @param {HTMLElement} itemRow Item Row.
@@ -94,22 +106,23 @@ function lookForMatch(fileName, lowerFileName, fileExtensions, isDir, isSubmodul
   // If it's a file.
   if (!isDir) {
     // First look in fileNames
-    if (iconMap.fileNames[fileName]) return iconMap.fileNames[fileName];
+    if (objectHas(iconMap.fileNames, fileName)) return iconMap.fileNames[fileName];
 
     // Then check all lowercase
-    if (iconMap.fileNames[lowerFileName]) return iconMap.fileNames[lowerFileName];
+    if (objectHas(iconMap.fileNames, lowerFileName)) return iconMap.fileNames[lowerFileName];
 
     // Look for extension in fileExtensions and languageIds.
     for (const ext of fileExtensions) {
-      if (iconMap.fileExtensions[ext]) return iconMap.fileExtensions[ext];
-      if (iconMap.languageIds[ext]) return iconMap.languageIds[ext];
+      if (objectHas(iconMap.fileExtensions, ext)) return iconMap.fileExtensions[ext];
+      if (objectHas(iconMap.languageIds, ext)) return iconMap.languageIds[ext];
     }
 
     // Look for filename and extension in VSCode language map.
-    if (languageMap.fileNames[fileName]) return languageMap.fileNames[fileName];
-    if (languageMap.fileNames[lowerFileName]) return languageMap.fileNames[lowerFileName];
+    if (objectHas(languageMap.fileNames, fileName)) return languageMap.fileNames[fileName];
+    if (objectHas(languageMap.fileNames, lowerFileName))
+      return languageMap.fileNames[lowerFileName];
     for (const ext of fileExtensions) {
-      if (languageMap.fileExtensions[ext]) return languageMap.fileExtensions[ext];
+      if (objectHas(languageMap.fileExtensions, ext)) return languageMap.fileExtensions[ext];
     }
 
     // Fallback into default file if no matches.
@@ -118,10 +131,10 @@ function lookForMatch(fileName, lowerFileName, fileExtensions, isDir, isSubmodul
 
   // Otherwise, it's a folder.
   // First look in folderNames.
-  if (iconMap.folderNames[fileName]) return iconMap.folderNames[fileName];
+  if (objectHas(iconMap.folderNames, fileName)) return iconMap.folderNames[fileName];
 
   // Then check all lowercase.
-  if (iconMap.folderNames[lowerFileName]) return iconMap.folderNames[lowerFileName];
+  if (objectHas(iconMap.folderNames, lowerFileName)) return iconMap.folderNames[lowerFileName];
 
   // Fallback into default folder if no matches.
   return 'folder';
@@ -162,29 +175,30 @@ function lookForIconPackMatch(iconPack, lowerFileName) {
   if (!iconPack) return null;
   switch (iconPack) {
     case 'angular':
-      if (iconsList[`folder-angular-${lowerFileName}.svg`])
+      if (objectHas(iconsList, `folder-angular-${lowerFileName}.svg`))
         return `folder-angular-${lowerFileName}`;
       break;
     case 'angular_ngrx':
-      if (iconsList[`folder-ngrx-${lowerFileName}.svg`]) return `folder-ngrx-${lowerFileName}`;
-      if (iconsList[`folder-angular-${lowerFileName}.svg`])
+      if (objectHas(iconsList, `folder-ngrx-${lowerFileName}.svg`))
+        return `folder-ngrx-${lowerFileName}`;
+      if (objectHas(iconsList, `folder-angular-${lowerFileName}.svg`))
         return `folder-angular-${lowerFileName}`;
       break;
     case 'react':
     case 'react_redux':
-      if (iconsList[`folder-react-${lowerFileName}.svg`]) {
+      if (objectHas(iconsList, `folder-react-${lowerFileName}.svg`)) {
         return `folder-react-${lowerFileName}`;
       }
-      if (iconsList[`folder-redux-${lowerFileName}.svg`]) {
+      if (objectHas(iconsList, `folder-redux-${lowerFileName}.svg`)) {
         return `folder-redux-${lowerFileName}`;
       }
       break;
     case 'vue':
     case 'vue_vuex':
-      if (iconsList[`folder-vuex-${lowerFileName}.svg`]) {
+      if (objectHas(iconsList, `folder-vuex-${lowerFileName}.svg`)) {
         return `folder-vuex-${lowerFileName}`;
       }
-      if (iconsList[`folder-vue-${lowerFileName}.svg`]) {
+      if (objectHas(iconsList, `folder-vue-${lowerFileName}.svg`)) {
         return `folder-vue-${lowerFileName}`;
       }
       if (lowerFileName === 'nuxt') {

--- a/src/main.js
+++ b/src/main.js
@@ -8,13 +8,11 @@ const { href } = window.location;
 const gitProvider = getGitProvider(href);
 
 Promise.all([
-getConfig('iconPack'),
-getConfig('extEnabled'),
-getConfig('extEnabled', 'default'),
+  getConfig('iconPack'),
+  getConfig('extEnabled'),
+  getConfig('extEnabled', 'default'),
 ]).then(([iconPack, extEnabled, globalExtEnabled]) => {
-  if (!globalExtEnabled || !extEnabled || !gitProvider) return
+  if (!globalExtEnabled || !extEnabled || !gitProvider) return;
   observePage(gitProvider, iconPack);
   onConfigChange('iconPack', (newIconPack) => replaceAllIcons(gitProvider, newIconPack));
-})
-
-
+});

--- a/src/ui/options/options.css
+++ b/src/ui/options/options.css
@@ -35,7 +35,7 @@ body {
   padding: 0 1rem;
   box-sizing: border-box;
   border-radius: 10px;
-  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   margin: 2rem;
   max-width: 800px;
 }
@@ -48,8 +48,8 @@ body {
 }
 
 #reset {
-  color:#5c6068;
-  padding:0.3rem 1rem;
+  color: #5c6068;
+  padding: 0.3rem 1rem;
   outline: transparent solid 2px;
   outline-offset: 2px;
   transition: 200ms all;
@@ -70,28 +70,29 @@ body {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap:0.5rem;
+  gap: 0.5rem;
   width: 100%;
   padding: 0 1rem;
-  border-top:1px solid #cbd5e0;
+  border-top: 1px solid #cbd5e0;
 }
 
 .domain.disabled {
-  background-color:rgb(177, 177, 177);
-  color:rgb(78, 78, 78)
+  background-color: rgb(177, 177, 177);
+  color: rgb(78, 78, 78);
 }
 
 .domain:hover {
-  background-color:rgb(232, 239, 250);
+  background-color: rgb(232, 239, 250);
 }
 
-.domain.disabled, .domain.disabled:hover {
-  background-color:rgb(177, 177, 177);
-  color:rgb(78, 78, 78)
+.domain.disabled,
+.domain.disabled:hover {
+  background-color: rgb(177, 177, 177);
+  color: rgb(78, 78, 78);
 }
 
 .domain h3 {
-  margin-right:auto;
+  margin-right: auto;
 }
 
 .domain:last-child {
@@ -108,18 +109,16 @@ body {
 }
 
 #row-default {
-  background-color:#cad9f7;
+  background-color: #cad9f7;
 }
 
-
 label {
-  color:#5c6068;
+  color: #5c6068;
   font-size: 0.9rem;
 }
 
-
 select {
-  padding:0.3rem 1rem;
+  padding: 0.3rem 1rem;
   outline: transparent solid 2px;
   outline-offset: 2px;
   appearance: none;
@@ -130,7 +129,7 @@ select {
   color: #2d3748;
   border-color: transparent;
   background-color: transparent;
-  min-width:100px;
+  min-width: 100px;
   text-align: end;
 }
 

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -17,36 +17,34 @@
       </div>
 
       <template id="domain-row">
-      <div class="domain">
-        <input type="checkbox" class="extEnabled"/>
+        <div class="domain">
+          <input type="checkbox" class="extEnabled" />
 
-        <h3 class="domain-name"></h3>
+          <h3 class="domain-name"></h3>
 
-        <label class="domain-icon-size-label">Icon Size:</label>
-        <div class="select-wrapper">
-          <select class="iconSize">
-            <option selected class="default-option" value="'default"></option>
-            <option value="sm">Small</option>
-            <option value="md">Medium</option>
-            <option value="lg">Large</option>
-            <option value="xl">Extra Large</option>
-          </select>
+          <label class="domain-icon-size-label">Icon Size:</label>
+          <div class="select-wrapper">
+            <select class="iconSize">
+              <option selected class="default-option" value="'default"></option>
+              <option value="sm">Small</option>
+              <option value="md">Medium</option>
+              <option value="lg">Large</option>
+              <option value="xl">Extra Large</option>
+            </select>
+          </div>
+
+          <label class="domain-icon-pack-label">Icon Pack:</label>
+          <div class="select-wrapper">
+            <select class="iconPack">
+              <option selected class="default-option" value="'default"></option>
+              <option value="angular">angular</option>
+              <option value="react">react</option>
+              <option value="vue">vue</option>
+              <option value="nest">nest</option>
+            </select>
+          </div>
         </div>
-
-        <label class="domain-icon-pack-label">Icon Pack:</label>
-        <div class="select-wrapper">
-          <select class="iconPack">
-            <option selected class="default-option" value="'default"></option>
-            <option value="angular">angular</option>
-            <option value="react">react</option>
-            <option value="vue">vue</option>
-            <option value="nest">nest</option>
-          </select>
-        </div>
-
-      </div>
-</template>
-
+      </template>
     </div>
 
     <div id="footer" class="centered">

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -1,7 +1,8 @@
+/* eslint-disable no-param-reassign */
 import { getConfig, setConfig, clearConfig, onConfigChange } from '../../lib/userConfig';
 import { providerConfig } from '../../providers';
 
-const resetButton = document.getElementById('reset')
+const resetButton = document.getElementById('reset');
 
 const newDomainRow = () => {
   const template = document.getElementById('domain-row');
@@ -16,75 +17,96 @@ const newDomainRow = () => {
  * @param {HTMLElement} row
  */
 const domainToggles = (row) => {
-  if (row.id === 'row-default') return
+  if (row.id === 'row-default') return;
 
   const toggleRow = (allEnabled) => {
-      const checkbox = row.querySelectorAll('.extEnabled').item(0)
-      if (checkbox instanceof HTMLInputElement) {
-        checkbox.disabled = !allEnabled
-        checkbox.indeterminate = !allEnabled
-      }
-      if (allEnabled) row.classList.remove('disabled')
-      else row.classList.add('disabled')
-  }
+    const checkbox = row.querySelectorAll('.extEnabled').item(0);
+    if (checkbox instanceof HTMLInputElement) {
+      checkbox.disabled = !allEnabled;
+      checkbox.indeterminate = !allEnabled;
+    }
+    if (allEnabled) row.classList.remove('disabled');
+    else row.classList.add('disabled');
+  };
 
-  getConfig('extEnabled', 'default').then(toggleRow)
-  onConfigChange('extEnabled', toggleRow, 'default')
-}
+  getConfig('extEnabled', 'default').then(toggleRow);
+  onConfigChange('extEnabled', toggleRow, 'default');
+};
 
 /**
  * @param {HTMLElement} row
  * @param {string} domain
  */
 const fillRow = (row, domain) => {
-  row.id = `row-${domain}`
+  row.id = `row-${domain}`;
 
-  const title = row.getElementsByClassName('domain-name').item(0)
-  title.appendChild(document.createTextNode(domain))
+  const title = row.getElementsByClassName('domain-name').item(0);
+  title.appendChild(document.createTextNode(domain));
 
   if (domain === 'default') {
-    [...row.getElementsByClassName('default-option')].forEach(opt => opt.remove())
+    [...row.getElementsByClassName('default-option')].forEach((opt) => opt.remove());
   }
 
   resetButton.addEventListener('click', () => {
-    row.classList.add('brightDomain')
-    setTimeout(() => row.classList.add('animated'), 0)
-    setTimeout(() => row.classList.remove('brightDomain'), 0)
-    setTimeout(() => row.classList.remove('animated'), 800)
-
+    row.classList.add('brightDomain');
+    setTimeout(() => row.classList.add('animated'), 0);
+    setTimeout(() => row.classList.remove('brightDomain'), 0);
+    setTimeout(() => row.classList.remove('animated'), 800);
   });
 
   const wireConfig = (config, updateInput, updateConfig) => {
-    const input = row.getElementsByClassName(config).item(0)
+    const input = row.getElementsByClassName(config).item(0);
 
-    const populateInput = () => getConfig(config, domain, false).then(updateInput(input))
+    const populateInput = () => getConfig(config, domain, false).then(updateInput(input));
 
     input.addEventListener('change', updateConfig(config));
     onConfigChange(config, updateInput(input), domain);
-    onConfigChange(config, () => getConfig(config, domain, false).then(updateInput(input)), 'default');
+    onConfigChange(
+      config,
+      () => getConfig(config, domain, false).then(updateInput(input)),
+      'default'
+    );
     resetButton.addEventListener('click', () => clearConfig(config, domain).then(populateInput));
 
-    [...input.getElementsByClassName('default-option')].forEach(opt => {
-      input.addEventListener('focus', () => opt.text = '(default)')
-      input.addEventListener('blur', () => opt.text = '')
-    })
+    [...input.getElementsByClassName('default-option')].forEach((opt) => {
+      input.addEventListener('focus', () => {
+        opt.text = '(default)';
+      });
+      input.addEventListener('blur', () => {
+        opt.text = '';
+      });
+    });
 
-    return populateInput()
-  }
+    return populateInput();
+  };
 
-  const updateSelect = (input) => val => {input.value = val ?? 'default'}
-  const updateConfigFromSelect = config => ({target: {value}}) => (!value || value === '(default)') ? clearConfig(config, domain) : setConfig(config, value, domain)
-  const wireSelect = (config) => wireConfig(config, updateSelect, updateConfigFromSelect)
+  const updateSelect = (input) => (val) => {
+    input.value = val ?? 'default';
+  };
+  const updateConfigFromSelect =
+    (config) =>
+    ({ target: { value } }) =>
+      !value || value === '(default)'
+        ? clearConfig(config, domain)
+        : setConfig(config, value, domain);
+  const wireSelect = (config) => wireConfig(config, updateSelect, updateConfigFromSelect);
 
-  const updateCheck = (input) => val => {input.checked = val ?? true}
-  const updateConfigFromCheck = config => ({target: {checked}}) => setConfig(config, checked, domain)
-  const wireCheck = (config) => wireConfig(config, updateCheck, updateConfigFromCheck)
+  const updateCheck = (input) => (val) => {
+    input.checked = val ?? true;
+  };
+  const updateConfigFromCheck =
+    (config) =>
+    ({ target: { checked } }) =>
+      setConfig(config, checked, domain);
+  const wireCheck = (config) => wireConfig(config, updateCheck, updateConfigFromCheck);
 
-  return Promise.all([wireSelect('iconSize'), wireSelect('iconPack'), wireCheck('extEnabled') ]).then(() => domainToggles(row)).then(() => row)
-}
-
+  return Promise.all([wireSelect('iconSize'), wireSelect('iconPack'), wireCheck('extEnabled')])
+    .then(() => domainToggles(row))
+    .then(() => row);
+};
 
 const domainsDiv = document.getElementById('domains');
-const domains = ['default', ...Object.values(providerConfig).map(p => p.domain)]
-Promise.all(domains.map(d => fillRow(newDomainRow(), d)))
-.then(rows => rows.forEach(r => domainsDiv.appendChild(r)))
+const domains = ['default', ...Object.values(providerConfig).map((p) => p.domain)];
+Promise.all(domains.map((d) => fillRow(newDomainRow(), d))).then((rows) =>
+  rows.forEach((r) => domainsDiv.appendChild(r))
+);

--- a/src/ui/popup/settings-popup.css
+++ b/src/ui/popup/settings-popup.css
@@ -30,7 +30,7 @@ body {
 }
 
 #logo {
-  margin-right:auto;
+  margin-right: auto;
   height: 24px;
   width: 24px;
 }
@@ -43,15 +43,15 @@ body {
 }
 
 #options-btn {
-  margin-left:auto;
-  width:24;
-  height:24;
-  filter:grayscale(1);
+  margin-left: auto;
+  width: 24;
+  height: 24;
+  filter: grayscale(1);
 }
 
 #options-btn:hover {
   cursor: pointer;
-  filter:brightness(0.8);
+  filter: brightness(0.8);
 }
 
 #domain {
@@ -72,7 +72,7 @@ body {
   color: maroon;
   margin: 2rem 0;
   display: none;
-  flex:1;
+  flex: 1;
 }
 
 #options-link {
@@ -81,7 +81,7 @@ body {
 }
 
 #options-link:hover {
-  filter:brightness(1.2)
+  filter: brightness(1.2);
 }
 
 label {

--- a/src/ui/popup/settings-popup.js
+++ b/src/ui/popup/settings-popup.js
@@ -55,9 +55,9 @@ function displayPageNotSupported(domain) {
 
 function displayAllDisabledNote() {
   getConfig('extEnabled', 'default').then((enabled) => {
-    if (enabled) return
-    document.getElementById('default-disabled-note').style.display = 'block'
-    document.getElementById('domain-settings').style.display = 'none'
+    if (enabled) return;
+    document.getElementById('default-disabled-note').style.display = 'block';
+    document.getElementById('domain-settings').style.display = 'none';
     document
       .getElementById('options-link')
       ?.addEventListener('click', () => chrome.runtime.openOptionsPage());


### PR DESCRIPTION
closes #68 

Shoot, well, I realized this problem is due to a change I made in my ESLint fix way back when haha. I switched from using `.hasOwnProperty` for all of the key checking to simply checking `object[key]`. This was to follow the [`no-prototype-builtins`](https://eslint.org/docs/latest/rules/no-prototype-builtins) ESLint rule. The problem with this being that it includes prototype properties like `constructor`. Anyway, I made a little helper function to check if an object has a property without including prototypes that still obeys this ESLint rule:

```js
/**
 * A helper function to check if an object has a key value, without including prooerties from the prototype chain.
 *
 * @see https://eslint.org/docs/latest/rules/no-prototype-builtins
 * @param {object} obj An object to check for a key.
 * @param {string} key A string represeing a key to find in the object.
 * @returns {boolean} Whether the object contains the key or not.
 */
function objectHas(obj, key) {
  return Object.prototype.hasOwnProperty.call(obj, key);
}
```

Also, I noticed that a bunch of files got slightly normalized by running `prettier --write .`, so I included them here as well, but I can remove those changes if you want me to.